### PR TITLE
Resolve ambiguous namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Cerbero\\:package_ns\\": "src"
+            "Cerbero\\:package_ns\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Cerbero\\:package_ns\\": "tests"
+            "Cerbero\\:package_ns\\Tests\\": "tests/"
         }
     },
     "scripts": {


### PR DESCRIPTION
## Description

Tell Composer what goes where.

## Motivation and context

Don't keep the same namespace in two locations.
PSR-4 is about matching filesystem to namespace.
